### PR TITLE
Leave .css files un-transformed

### DIFF
--- a/src/helpers/__tests__/fixtures/test.module.css
+++ b/src/helpers/__tests__/fixtures/test.module.css
@@ -11,6 +11,7 @@
 }
 
 .class_d {
+  @mixin thisBreaksSass;
   color: rebeccapurple;
 }
 

--- a/src/helpers/cssSnapshots.ts
+++ b/src/helpers/cssSnapshots.ts
@@ -23,10 +23,15 @@ const flattenClassNames = (
 export const enum FileTypes {
   scss = 'scss',
   less = 'less',
+  css = 'css',
 }
 
 export const getFileType = (fileName: string) =>
-  fileName.endsWith('less') ? FileTypes.less : FileTypes.scss;
+  fileName.endsWith('.css')
+    ? FileTypes.css
+    : fileName.endsWith('.less')
+    ? FileTypes.less
+    : FileTypes.scss;
 
 export const getClasses = (css: string, fileType: FileTypes) => {
   try {
@@ -36,8 +41,10 @@ export const getClasses = (css: string, fileType: FileTypes) => {
       less.render(css, { asyncImport: true } as any, (err, output) => {
         transformedCss = output.css.toString();
       });
-    } else {
+    } else if (fileType === FileTypes.scss) {
       transformedCss = sass.renderSync({ data: css }).css.toString();
+    } else {
+      transformedCss = css;
     }
 
     const processedCss = processor.process(transformedCss);


### PR DESCRIPTION
Projects using PostCSS may have enabled plugins which can result in `.css` files that cannot be parsed by the Sass compiler. In my case, the [`postcss-mixins`](https://github.com/postcss/postcss-mixins) plugin uses a reserved Sass at-rule (`@mixin`) in an incompatible way, causing the transformer to fail.

Since PostCSS is able to extract nested selectors without any kind of transformation, we can pass in the source as-is for plain CSS files.