### PR TITLE
Add relative @import support

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/sass": "^1.16.0",
     "husky": "^2.7.0",
     "jest": "^24.8.0",
+    "postcss-import-sync2": "^1.1.0",
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.1",
     "ts-jest": "^24.0.2",

--- a/src/@types/postcss-import-sync2.d.ts
+++ b/src/@types/postcss-import-sync2.d.ts
@@ -1,0 +1,5 @@
+declare module 'postcss-import-sync2' {
+  import { Plugin } from 'postcss';
+  const plugin: Plugin<{}>;
+  export = plugin;
+}

--- a/src/helpers/DtsSnapshotCreator.ts
+++ b/src/helpers/DtsSnapshotCreator.ts
@@ -43,9 +43,13 @@ export class DtsSnapshotCreator {
       let transformedCss = '';
 
       if (fileType === FileTypes.less) {
-        less.render(css, { asyncImport: true } as any, (err, output) => {
-          transformedCss = output.css.toString();
-        });
+        less.render(
+          css,
+          { syncImport: true, filename: fileName } as any,
+          (err, output) => {
+            transformedCss = output.css.toString();
+          },
+        );
       } else if (fileType === FileTypes.scss) {
         const filePath = getFilePath(fileName);
         transformedCss = sass

--- a/src/helpers/DtsSnapshotCreator.ts
+++ b/src/helpers/DtsSnapshotCreator.ts
@@ -58,7 +58,9 @@ export class DtsSnapshotCreator {
         transformedCss = css;
       }
 
-      const processedCss = processor.process(transformedCss);
+      const processedCss = processor.process(transformedCss, {
+        from: fileName,
+      });
 
       return processedCss.root
         ? extractICSS(processedCss.root).icssExports

--- a/src/helpers/__tests__/DtsSnapshotCreator.test.ts
+++ b/src/helpers/__tests__/DtsSnapshotCreator.test.ts
@@ -3,6 +3,7 @@ import { IICSSExports } from 'icss-utils';
 import { join } from 'path';
 import * as postcss from 'postcss';
 import * as postcssIcssSelectors from 'postcss-icss-selectors';
+import * as postcssImportSync from 'postcss-import-sync2';
 import { DtsSnapshotCreator } from '../DtsSnapshotCreator';
 
 const testFileNames = [
@@ -11,9 +12,13 @@ const testFileNames = [
   'test.module.scss',
   'empty.module.less',
   'empty.module.scss',
+  'import.module.css',
 ];
 
-const processor = postcss([postcssIcssSelectors({ mode: 'local' })]);
+const processor = postcss([
+  postcssImportSync(),
+  postcssIcssSelectors({ mode: 'local' }),
+]);
 
 describe('utils / cssSnapshots', () => {
   testFileNames.forEach((fileName) => {

--- a/src/helpers/__tests__/DtsSnapshotCreator.test.ts
+++ b/src/helpers/__tests__/DtsSnapshotCreator.test.ts
@@ -13,6 +13,7 @@ const testFileNames = [
   'empty.module.less',
   'empty.module.scss',
   'import.module.css',
+  'import.module.less',
 ];
 
 const processor = postcss([

--- a/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
@@ -43,14 +43,14 @@ export const nestedChild: string;
 
 exports[`utils / cssSnapshots with file 'import.module.css' getClasses should return an object matching expected CSS 1`] = `
 Object {
-  "ClassB": "import-module__ClassB---1uTmq",
-  "childA": "import-module__childA---39Yod",
-  "childB": "import-module__childB---2S1Lz",
-  "class-c": "import-module__class-c---Xdyrv",
-  "classA": "import-module__classA---3-9yK",
-  "class_d": "import-module__class_d---27FnC",
-  "nestedChild": "import-module__nestedChild---HAsOX",
-  "parent": "import-module__parent---11jeJ",
+  "ClassB": "import-module__ClassB---2LsIz",
+  "childA": "import-module__childA---2AUKk",
+  "childB": "import-module__childB---1z-Zh",
+  "class-c": "import-module__class-c---2JDAJ",
+  "classA": "import-module__classA---2fO5r",
+  "class_d": "import-module__class_d---2Dims",
+  "nestedChild": "import-module__nestedChild---1ZDxw",
+  "parent": "import-module__parent---2kdvO",
 }
 `;
 
@@ -73,16 +73,16 @@ export default classes;
 
 exports[`utils / cssSnapshots with file 'import.module.less' getClasses should return an object matching expected CSS 1`] = `
 Object {
-  "child-class": "import-module__child-class---3rUzY",
-  "color-set": "import-module__color-set---1Nz_3",
-  "column-1": "import-module__column-1---1do6Y",
-  "column-2": "import-module__column-2---HjqfU",
-  "column-3": "import-module__column-3---N5Wnb",
-  "column-4": "import-module__column-4---23ZMh",
-  "nested-class-parent": "import-module__nested-class-parent---36rk0",
-  "selector-blue": "import-module__selector-blue---1tI9n",
-  "selector-green": "import-module__selector-green---2yk8M",
-  "selector-red": "import-module__selector-red---1SN6v",
+  "child-class": "import-module__child-class---2XACw",
+  "color-set": "import-module__color-set---9xoPb",
+  "column-1": "import-module__column-1---3R-BM",
+  "column-2": "import-module__column-2---J0ZdX",
+  "column-3": "import-module__column-3---3_589",
+  "column-4": "import-module__column-4---SlPDz",
+  "nested-class-parent": "import-module__nested-class-parent---14g9m",
+  "selector-blue": "import-module__selector-blue---2JSaB",
+  "selector-green": "import-module__selector-green---1cLL8",
+  "selector-red": "import-module__selector-red---2T6zy",
 }
 `;
 
@@ -109,14 +109,14 @@ export const nestedChild: string;
 
 exports[`utils / cssSnapshots with file 'test.module.css' getClasses should return an object matching expected CSS 1`] = `
 Object {
-  "ClassB": "test-module__ClassB---1z7xQ",
-  "childA": "test-module__childA---3PtDp",
-  "childB": "test-module__childB---33c4a",
-  "class-c": "test-module__class-c---Nme_S",
-  "classA": "test-module__classA---11Lf2",
-  "class_d": "test-module__class_d---7rY6T",
-  "nestedChild": "test-module__nestedChild---3OSwX",
-  "parent": "test-module__parent---1pNsk",
+  "ClassB": "test-module__ClassB---G7fhY",
+  "childA": "test-module__childA---26dwC",
+  "childB": "test-module__childB---13lLy",
+  "class-c": "test-module__class-c---3Ouzp",
+  "classA": "test-module__classA---KAOw8",
+  "class_d": "test-module__class_d---3pjDe",
+  "nestedChild": "test-module__nestedChild---v7rOR",
+  "parent": "test-module__parent---2tsUX",
 }
 `;
 
@@ -139,16 +139,16 @@ export default classes;
 
 exports[`utils / cssSnapshots with file 'test.module.less' getClasses should return an object matching expected CSS 1`] = `
 Object {
-  "child-class": "test-module__child-class---1Ga8C",
-  "color-set": "test-module__color-set---2h232",
-  "column-1": "test-module__column-1---3Hv-0",
-  "column-2": "test-module__column-2---1QOqJ",
-  "column-3": "test-module__column-3---1PZz0",
-  "column-4": "test-module__column-4---2XpQh",
-  "nested-class-parent": "test-module__nested-class-parent---R9jV3",
-  "selector-blue": "test-module__selector-blue---1icL9",
-  "selector-green": "test-module__selector-green---2pD8c",
-  "selector-red": "test-module__selector-red---gsEUj",
+  "child-class": "test-module__child-class---1au0d",
+  "color-set": "test-module__color-set---bEXmh",
+  "column-1": "test-module__column-1---5hXb3",
+  "column-2": "test-module__column-2---2ykNv",
+  "column-3": "test-module__column-3---2JnAp",
+  "column-4": "test-module__column-4---SG3xj",
+  "nested-class-parent": "test-module__nested-class-parent---2jIpC",
+  "selector-blue": "test-module__selector-blue---2kUKa",
+  "selector-green": "test-module__selector-green---hMr6S",
+  "selector-red": "test-module__selector-red---2hf4j",
 }
 `;
 
@@ -181,25 +181,25 @@ export default classes;
 
 exports[`utils / cssSnapshots with file 'test.module.scss' getClasses should return an object matching expected CSS 1`] = `
 Object {
-  "child-class": "file__child-class---1QWYM",
-  "class-with-mixin": "file__class-with-mixin---39EVY",
-  "const": "file__const---MIe_0",
-  "default": "file__default---2RWlj",
-  "local-class": "file__local-class---3SW3k",
-  "local-class-2": "file__local-class-2----c5z7",
-  "local-class-inside-global": "file__local-class-inside-global---1T0um",
-  "local-class-inside-local": "file__local-class-inside-local---1Z9pB",
-  "nested-class-parent": "file__nested-class-parent---3qXdF",
-  "nested-class-parent--extended": "file__nested-class-parent--extended---qsVau",
-  "reserved-words": "file__reserved-words---_rrID",
-  "section-1": "file__section-1---1IHCS",
-  "section-2": "file__section-2---cLFhf",
-  "section-3": "file__section-3---1ldKa",
-  "section-4": "file__section-4---2u0CG",
-  "section-5": "file__section-5---1lAYL",
-  "section-6": "file__section-6---2YZ9I",
-  "section-7": "file__section-7---3w-OF",
-  "section-8": "file__section-8---3RB8g",
-  "section-9": "file__section-9---3_Mtj",
+  "child-class": "test-module__child-class---s-_Mc",
+  "class-with-mixin": "test-module__class-with-mixin---1JqB_",
+  "const": "test-module__const---28kKv",
+  "default": "test-module__default---8gLb1",
+  "local-class": "test-module__local-class---1Ju3l",
+  "local-class-2": "test-module__local-class-2---3aSgy",
+  "local-class-inside-global": "test-module__local-class-inside-global---IVh9J",
+  "local-class-inside-local": "test-module__local-class-inside-local---1LKIi",
+  "nested-class-parent": "test-module__nested-class-parent---2LnTV",
+  "nested-class-parent--extended": "test-module__nested-class-parent--extended---1j85b",
+  "reserved-words": "test-module__reserved-words---1mM1m",
+  "section-1": "test-module__section-1---11Ic3",
+  "section-2": "test-module__section-2---1Uiwc",
+  "section-3": "test-module__section-3---2eZeM",
+  "section-4": "test-module__section-4---3m8sf",
+  "section-5": "test-module__section-5---1MTwN",
+  "section-6": "test-module__section-6---szUAt",
+  "section-7": "test-module__section-7---2DOBJ",
+  "section-8": "test-module__section-8---3qav2",
+  "section-9": "test-module__section-9---2EMR_",
 }
 `;

--- a/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
@@ -54,6 +54,16 @@ Object {
 }
 `;
 
+exports[`utils / cssSnapshots with file 'import.module.less' createExports should create an exports file 1`] = `
+"declare const classes: {
+  
+};
+export default classes;
+"
+`;
+
+exports[`utils / cssSnapshots with file 'import.module.less' getClasses should return an object matching expected CSS 1`] = `Object {}`;
+
 exports[`utils / cssSnapshots with file 'test.module.css' createExports should create an exports file 1`] = `
 "declare const classes: {
   'classA': string;

--- a/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
@@ -56,13 +56,35 @@ Object {
 
 exports[`utils / cssSnapshots with file 'import.module.less' createExports should create an exports file 1`] = `
 "declare const classes: {
-  
+  'nested-class-parent': string;
+  'child-class': string;
+  'selector-blue': string;
+  'selector-green': string;
+  'selector-red': string;
+  'column-1': string;
+  'column-2': string;
+  'column-3': string;
+  'column-4': string;
+  'color-set': string;
 };
 export default classes;
 "
 `;
 
-exports[`utils / cssSnapshots with file 'import.module.less' getClasses should return an object matching expected CSS 1`] = `Object {}`;
+exports[`utils / cssSnapshots with file 'import.module.less' getClasses should return an object matching expected CSS 1`] = `
+Object {
+  "child-class": "import-module__child-class---3rUzY",
+  "color-set": "import-module__color-set---1Nz_3",
+  "column-1": "import-module__column-1---1do6Y",
+  "column-2": "import-module__column-2---HjqfU",
+  "column-3": "import-module__column-3---N5Wnb",
+  "column-4": "import-module__column-4---23ZMh",
+  "nested-class-parent": "import-module__nested-class-parent---36rk0",
+  "selector-blue": "import-module__selector-blue---1tI9n",
+  "selector-green": "import-module__selector-green---2yk8M",
+  "selector-red": "import-module__selector-red---1SN6v",
+}
+`;
 
 exports[`utils / cssSnapshots with file 'test.module.css' createExports should create an exports file 1`] = `
 "declare const classes: {

--- a/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
@@ -20,6 +20,40 @@ export default classes;
 
 exports[`utils / cssSnapshots with file 'empty.module.scss' getClasses should return an object matching expected CSS 1`] = `Object {}`;
 
+exports[`utils / cssSnapshots with file 'import.module.css' createExports should create an exports file 1`] = `
+"declare const classes: {
+  'classA': string;
+  'ClassB': string;
+  'class-c': string;
+  'class_d': string;
+  'parent': string;
+  'childA': string;
+  'childB': string;
+  'nestedChild': string;
+};
+export default classes;
+export const classA: string;
+export const ClassB: string;
+export const parent: string;
+export const childA: string;
+export const childB: string;
+export const nestedChild: string;
+"
+`;
+
+exports[`utils / cssSnapshots with file 'import.module.css' getClasses should return an object matching expected CSS 1`] = `
+Object {
+  "ClassB": "import-module__ClassB---1uTmq",
+  "childA": "import-module__childA---39Yod",
+  "childB": "import-module__childB---2S1Lz",
+  "class-c": "import-module__class-c---Xdyrv",
+  "classA": "import-module__classA---3-9yK",
+  "class_d": "import-module__class_d---27FnC",
+  "nestedChild": "import-module__nestedChild---HAsOX",
+  "parent": "import-module__parent---11jeJ",
+}
+`;
+
 exports[`utils / cssSnapshots with file 'test.module.css' createExports should create an exports file 1`] = `
 "declare const classes: {
   'classA': string;

--- a/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/DtsSnapshotCreator.test.ts.snap
@@ -109,14 +109,14 @@ export const nestedChild: string;
 
 exports[`utils / cssSnapshots with file 'test.module.css' getClasses should return an object matching expected CSS 1`] = `
 Object {
-  "ClassB": "file__ClassB---2bPVi",
-  "childA": "file__childA---1hjQD",
-  "childB": "file__childB---pq4Ks",
-  "class-c": "file__class-c---DZ1TD",
-  "classA": "file__classA---2xcnJ",
-  "class_d": "file__class_d---1mwNi",
-  "nestedChild": "file__nestedChild---2d15b",
-  "parent": "file__parent---1ATMj",
+  "ClassB": "test-module__ClassB---1z7xQ",
+  "childA": "test-module__childA---3PtDp",
+  "childB": "test-module__childB---33c4a",
+  "class-c": "test-module__class-c---Nme_S",
+  "classA": "test-module__classA---11Lf2",
+  "class_d": "test-module__class_d---7rY6T",
+  "nestedChild": "test-module__nestedChild---3OSwX",
+  "parent": "test-module__parent---1pNsk",
 }
 `;
 
@@ -139,16 +139,16 @@ export default classes;
 
 exports[`utils / cssSnapshots with file 'test.module.less' getClasses should return an object matching expected CSS 1`] = `
 Object {
-  "child-class": "file__child-class---1mwoB",
-  "color-set": "file__color-set---9sHH_",
-  "column-1": "file__column-1---vHRb_",
-  "column-2": "file__column-2---28y1r",
-  "column-3": "file__column-3---1PsZw",
-  "column-4": "file__column-4---2qaaI",
-  "nested-class-parent": "file__nested-class-parent---_ft7G",
-  "selector-blue": "file__selector-blue---3mslq",
-  "selector-green": "file__selector-green---143xX",
-  "selector-red": "file__selector-red---Gckob",
+  "child-class": "test-module__child-class---1Ga8C",
+  "color-set": "test-module__color-set---2h232",
+  "column-1": "test-module__column-1---3Hv-0",
+  "column-2": "test-module__column-2---1QOqJ",
+  "column-3": "test-module__column-3---1PZz0",
+  "column-4": "test-module__column-4---2XpQh",
+  "nested-class-parent": "test-module__nested-class-parent---R9jV3",
+  "selector-blue": "test-module__selector-blue---1icL9",
+  "selector-green": "test-module__selector-green---2pD8c",
+  "selector-red": "test-module__selector-red---gsEUj",
 }
 `;
 

--- a/src/helpers/__tests__/fixtures/import.module.css
+++ b/src/helpers/__tests__/fixtures/import.module.css
@@ -1,0 +1,1 @@
+@import 'test.module.css';

--- a/src/helpers/__tests__/fixtures/import.module.less
+++ b/src/helpers/__tests__/fixtures/import.module.less
@@ -1,0 +1,1 @@
+@import 'test.module.less';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,6 +3138,11 @@ picomatch@^2.0.4:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
+pify@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
@@ -3197,6 +3202,16 @@ postcss-icss-selectors@^2.0.3:
     lodash "^4.17.4"
     postcss "^6.0.2"
 
+postcss-import-sync2@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-import-sync2/-/postcss-import-sync2-1.1.0.tgz#768fa23bc7e2248d0560553e42e75e38c841b2d6"
+  integrity sha512-wPjRneS2QUqd8eA2lDeZeQMAqk232aha42XFlEY4O3MMOoZ43VWH4npPt0F7GC7WT7oEIjuS2W7CyH8lgHczOw==
+  dependencies:
+    postcss "^7"
+    postcss-value-parser "^3.3.1"
+    read-cache "^1.0.0"
+    resolve "^1.8.1"
+
 postcss-load-config@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-2.1.0.tgz#c84d692b7bb7b41ddced94ee62e8ab31b417b003"
@@ -3204,6 +3219,11 @@ postcss-load-config@^2.1.0:
   dependencies:
     cosmiconfig "^5.0.0"
     import-cwd "^2.0.0"
+
+postcss-value-parser@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
+  integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
 postcss@^6.0.2:
   version "6.0.23"
@@ -3214,19 +3234,19 @@ postcss@^6.0.2:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.14:
-  version "7.0.17"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.17.tgz#4da1bdff5322d4a0acaab4d87f3e782436bad31f"
-  integrity sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==
+postcss@^7, postcss@^7.0.17:
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.18.tgz#4b9cda95ae6c069c67a4d933029eddd4838ac233"
+  integrity sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^7.0.17:
-  version "7.0.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.18.tgz#4b9cda95ae6c069c67a4d933029eddd4838ac233"
-  integrity sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==
+postcss@^7.0.14:
+  version "7.0.17"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.17.tgz#4da1bdff5322d4a0acaab4d87f3e782436bad31f"
+  integrity sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -3336,6 +3356,13 @@ react-is@^16.8.4:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  integrity sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=
+  dependencies:
+    pify "^2.3.0"
 
 read-pkg-up@^4.0.0:
   version "4.0.0"
@@ -3519,7 +3546,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.3.2:
+resolve@1.x, resolve@^1.3.2, resolve@^1.8.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==


### PR DESCRIPTION
Fixes #47 and #48.

Adds support for local `@import` at-rules for pure css and less stylesheets.
It's done via passing proper `from`/`filename` to postcss/less renderers as discussed [here](https://github.com/mrmckeb/typescript-plugin-css-modules/issues/48).

I've also added couple of tests and `postcss-import-sync2` dev dependency for those tests to work.

Unfortunatelly `*.scss` tests are failing for me with empty received snapshot (even at `origin/develop` without any modifications) and i've never worked with SCSS, so I did not dare to change anything related to scss. And I had to push with `--no-verify` to skip husky, but all other tests are passing.

As a side effect of those modifications local class names have changed: the common "file___" prefix is now substituted by real file name (i.e. "test-module__" or "import-module__") - this is reflected in snapshots. As those values are never ment to be used directly by anyone, this change does not seem relative or harmful in any way.