### PR TITLE
Add .env SASS_PATH support

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
+    "dotenv": "^8.1.0",
     "icss-utils": "^4.1.1",
     "less": "^3.9.0",
     "lodash": "^4.17.14",
@@ -57,6 +58,7 @@
     "sass": "^1.22.4"
   },
   "devDependencies": {
+    "@types/dotenv": "^6.1.1",
     "@types/jest": "^24.0.15",
     "@types/less": "^3.0.0",
     "@types/lodash": "^4.14.136",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "dotenv": "^8.1.0",
     "icss-utils": "^4.1.1",
     "less": "^3.9.0",
     "lodash": "^4.17.14",
@@ -58,7 +57,6 @@
     "sass": "^1.22.4"
   },
   "devDependencies": {
-    "@types/dotenv": "^6.1.1",
     "@types/jest": "^24.0.15",
     "@types/less": "^3.0.0",
     "@types/lodash": "^4.14.136",

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,25 +192,27 @@ function init({ typescript: ts }: { typescript: typeof ts_module }) {
     // Manually open .env and parse just the SASS_PATH part,
     // because we don't *need* to apply the full .env to this environment,
     // and we are not sure doing so wouldn't have side effects
-    const dotenv = fs.readFileSync(dotenvPath, { encoding: 'utf8' });
-    const sassPathMatch = sassPathRegex.exec(dotenv);
+    try {
+      const dotenv = fs.readFileSync(dotenvPath, { encoding: 'utf8' });
+      const sassPathMatch = sassPathRegex.exec(dotenv);
 
-    if (sassPathMatch && sassPathMatch[1]) {
-      const sassPaths = sassPathMatch[1].split(path.delimiter);
+      if (sassPathMatch && sassPathMatch[1]) {
+        const sassPaths = sassPathMatch[1].split(path.delimiter);
 
-      // Manually convert relative paths in SASS_PATH to absolute,
-      // lest they be resolved relative to process.cwd which would almost certainly be wrong
-      for (
-        var i = 0, currPath = sassPaths[i];
-        i < sassPaths.length;
-        currPath = sassPaths[++i]
-      ) {
-        if (path.isAbsolute(currPath)) continue;
-        sassPaths[i] = path.resolve(projectDir, currPath); // resolve path relative to project directory
+        // Manually convert relative paths in SASS_PATH to absolute,
+        // lest they be resolved relative to process.cwd which would almost certainly be wrong
+        for (
+          var i = 0, currPath = sassPaths[i];
+          i < sassPaths.length;
+          currPath = sassPaths[++i]
+        ) {
+          if (path.isAbsolute(currPath)) continue;
+          sassPaths[i] = path.resolve(projectDir, currPath); // resolve path relative to project directory
+        }
+        // join modified array and assign to environment SASS_PATH
+        process.env.SASS_PATH = sassPaths.join(path.delimiter);
       }
-      // join modified array and assign to environment SASS_PATH
-      process.env.SASS_PATH = sassPaths.join(path.delimiter);
-    }
+    } catch {}
 
     return info.languageService;
   }


### PR DESCRIPTION
Fixes #49 

Adds support for resolving `@import`s in `*.scss` files using the paths defined in `SASS_PATH` in a `.env` file at the project root.

Works by reading in the `.env` file during initialization and adding its `SASS_PATH` value (after some fix-up to relative paths) to `process.env.SASS_PATH`, where `dart-sass` will find it and use it.

Unfortunately, like #50 the other currently pending pull request on this repo, I too have failing `*.scss` tests with empty received snapshot, even with no modifications from upstream `origin/develop`.  All other tests are passing.