### PR TITLE
Allow passing options to SCSS/Less render functions

### DIFF
--- a/src/helpers/DtsSnapshotCreator.ts
+++ b/src/helpers/DtsSnapshotCreator.ts
@@ -57,6 +57,7 @@ export class DtsSnapshotCreator {
       }
 
       if (fileType === FileTypes.less) {
+        let error;
         less.render(
           css,
           {
@@ -65,9 +66,15 @@ export class DtsSnapshotCreator {
             ...renderOptions,
           } as any,
           (err, output) => {
-            transformedCss = output.css.toString();
+            error = err;
+            if (output) {
+              transformedCss = output.css.toString();
+            }
           },
         );
+        if (error) {
+          throw error;
+        }
       } else if (fileType === FileTypes.scss) {
         const filePath = getFilePath(fileName);
         transformedCss = sass

--- a/src/helpers/DtsSnapshotCreator.ts
+++ b/src/helpers/DtsSnapshotCreator.ts
@@ -37,15 +37,33 @@ const getFilePath = (fileName: string) =>
 export class DtsSnapshotCreator {
   constructor(private readonly logger: Logger) {}
 
-  getClasses(processor: postcss.Processor, css: string, fileName: string) {
+  getClasses(
+    processor: postcss.Processor,
+    css: string,
+    fileName: string,
+    options: Options = {},
+  ) {
     try {
       const fileType = getFileType(fileName);
       let transformedCss = '';
 
+      let renderOptions: Options['renderOptions'] | {} = {};
+      if (options.renderOptions) {
+        if (fileType === FileTypes.less && options.renderOptions.less) {
+          renderOptions = options.renderOptions.less;
+        } else if (fileType === FileTypes.scss && options.renderOptions.scss) {
+          renderOptions = options.renderOptions.scss;
+        }
+      }
+
       if (fileType === FileTypes.less) {
         less.render(
           css,
-          { syncImport: true, filename: fileName } as any,
+          {
+            syncImport: true,
+            filename: fileName,
+            ...renderOptions,
+          } as any,
           (err, output) => {
             transformedCss = output.css.toString();
           },
@@ -56,6 +74,7 @@ export class DtsSnapshotCreator {
           .renderSync({
             data: css,
             includePaths: [filePath],
+            ...options,
           })
           .css.toString();
       } else {
@@ -116,7 +135,7 @@ export default classes;
       return scriptSnapshot;
     }
 
-    const classes = this.getClasses(processor, css, fileName);
+    const classes = this.getClasses(processor, css, fileName, options);
     const dts = this.createExports(classes, options);
     return ts.ScriptSnapshot.fromString(dts);
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,12 @@
+import { Options as SassOptions } from 'sass';
+
 export interface Options {
   camelCase?: CamelCaseOptions;
   customMatcher?: string;
+  renderOptions?: {
+    less?: Partial<Less.Options>;
+    scss?: Partial<SassOptions>;
+  };
 }
 
 export type CamelCaseOptions =


### PR DESCRIPTION
This PR allows the user to pass options to the render function called for less or scss files.

My use-case for this is passing the `paths` option to the less configuration like this:

```json
{
  "compilerOptions": {
    "plugins": [
      {
        "name": "typescript-plugin-css-modules",
        "options": {
          "renderOptions": {
            "less": {
              "paths": ["src/"]
            }
          }
        }
      }
    ]
  }
}
```

This allows me to use path aliases in my webpack config and match those in the less configuration to fix the import errors that occur because of said aliases.

In addition to that, I added some improvements to the error handling for when less fails to render the file. Previously, there would be an error like `Cannot read property 'css' of undefined` since the `output` is not passed into the callback if there was an error (I have made a PR to reflect this in the typings: [DefinitelyTyped/DefinitelyTyped#39261][1]).

[1]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39261