### PR TITLE
Improved Webpack-style tilde-import support for Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ The `classes` object represents all the classnames extracted from the CSS Module
 
 #### `rendererOptions`
 
-| Option   | Default value | Description                                                                          |
-| -------- | ------------- | ------------------------------------------------------------------------------------ |
-| `less`   | `{}`          | Set [renderer options for Less](http://lesscss.org/usage/#less-options).             |
-| `sass`   | `{}`          | Set [renderer options for Sass](https://sass-lang.com/documentation/js-api#options). |
-| `stylus` | `{}`          | Set [renderer options for Stylus](https://stylus.bootcss.com/docs/js.html).          |
+| Option   | Default value                         | Description                                                                                                                                                                                                                              |
+| -------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `less`   | `{}`                                  | Set [renderer options for Less](http://lesscss.org/usage/#less-options).                                                                                                                                                                 |
+| `sass`   | `{ enableWebpackTildeImports: true }` | Set [renderer options for Sass](https://sass-lang.com/documentation/js-api#options). The `enableWebpackTildeImports` property enables support for [Webpack's tilde-prefixed imports](https://webpack.js.org/loaders/css-loader/#import). |
+| `stylus` | `{}`                                  | Set [renderer options for Stylus](https://stylus.bootcss.com/docs/js.html).                                                                                                                                                              |
 
 > For convenience, `includePaths` for Sass are extended, not replaced. The defaults are the path of the current file, and `'node_modules'`.
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,9 +13,13 @@ export interface PostCssOptions {
   useConfig?: boolean;
 }
 
+export interface ExtraSassOptions {
+  enableWebpackTildeImports?: boolean;
+}
+
 export interface RendererOptions {
   less?: Partial<Less.Options>;
-  sass?: Partial<SassOptions>;
+  sass?: Partial<SassOptions> & ExtraSassOptions;
   stylus?: Partial<StylusRenderOptions>;
 }
 


### PR DESCRIPTION
The current solution for dealing with sass/scss imports which are
prefixed with a tilde (~) is to strip the symbol from the import line.
This breaks down when dart-sass itself starts pulling in subsequent
imports that are also tilde-prefixed.

This change introduces a simple algorithm to climb the filesystem tree
looking for the imported module/file in a node_modules directory.

This is enabled by default since it replaces behavior which is already
forced on.

This change is covered under the existing "with a Bootstrap import"
test.