### PR TITLE
Support sass index files

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "lint-staged": "^10.1.7",
     "postcss-import-sync2": "^1.1.0",
     "prettier": "^2.0.5",
+    "sass-svg": "1.2.0",
     "ts-jest": "^25.4.0",
     "typescript": "^3.8.3"
   },

--- a/src/importers/__tests__/sassTildeImporter.ts
+++ b/src/importers/__tests__/sassTildeImporter.ts
@@ -38,6 +38,12 @@ describe('importers / sassTildeImporter', () => {
     ).toMatchObject({ file: 'node_modules/bootstrap/scss/_grid.scss' });
   });
 
+  it('should resolve index files', () => {
+    expect(sassTildeImporter('~sass-svg', source, done)).toMatchObject({
+      file: 'node_modules/sass-svg/_index.scss',
+    });
+  });
+
   it('should resolve .css files', () => {
     expect(
       sassTildeImporter('~bootstrap/dist/css/bootstrap-grid.css', source, done),

--- a/src/importers/sassTildeImporter.ts
+++ b/src/importers/sassTildeImporter.ts
@@ -34,6 +34,12 @@ export const sassTildeImporter: sass.Importer = (
     );
   }
 
+  // Support index files.
+  subpathsWithExts.push(
+    `${nodeModSubpath}/_index.scss`,
+    `${nodeModSubpath}/_index.sass`,
+  );
+
   // Support sass partials by including paths where the file is prefixed by an underscore.
   const basename = path.basename(nodeModSubpath);
   if (!basename.startsWith('_')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4240,12 +4240,24 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sass-svg@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sass-svg/-/sass-svg-1.2.0.tgz#dc7b954d073fe2416d9e069973b2ba4c658534b9"
+  integrity sha512-xEEyBGdzAGTAw3Njy8mNHoRmoD/VpXd75ENmSUh5EfvnvTUCxYta0i/PshBKZFudhfbTvfQAUiihfD+yLE0Arw==
+  dependencies:
+    sassdash "^0.9.0"
+
 sass@^1.26.5:
   version "1.26.5"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.26.5.tgz#2d7aecfbbabfa298567c8f06615b6e24d2d68099"
   integrity sha512-FG2swzaZUiX53YzZSjSakzvGtlds0lcbF+URuU9mxOv7WBh7NhXEVDa4kPKN4hN6fC2TkOTOKqiqp6d53N9X5Q==
   dependencies:
     chokidar ">=2.0.0 <4.0.0"
+
+sassdash@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/sassdash/-/sassdash-0.9.0.tgz#e2114e80af0c01639d1c6b88a3eb350740cb1169"
+  integrity sha512-1SIJltpUOCMY06uTEWrtXDtfGr39P2huhikbiAMU0v9S4PfL5StxGiz5Oo0HqyVpWZK3mAItYEntDikUSUyXeQ==
 
 sax@~1.2.4:
   version "1.2.4"


### PR DESCRIPTION
This PR adds support for [index files](https://sass-lang.com/documentation/at-rules/use#index-files) in Sass.

With these changes the plugin supports writing `~library/folder` to import the `~library/folder/_index.scss` file.

The 'sass-svg' library is added for testing, this is the first publicly available library I found with an `_index.scss` file.