### PR TITLE
Move to lowercase `postcss`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for [CSS Modules](https://github.com/css-modules/css-modules).
       - [`classnameTransform`](#classnametransform)
       - [`customRenderer`](#customrenderer)
       - [`customTemplate`](#customtemplate)
-      - [`postCssOptions`](#postcssoptions)
+      - [`postcssOptions`](#postcssoptions)
       - [`rendererOptions`](#rendereroptions)
     - [Visual Studio Code](#visual-studio-code)
       - [Recommended usage](#recommended-usage)
@@ -105,7 +105,7 @@ Please note that no options are required. However, depending on your configurati
 | `customTemplate`     | `false`                            | See [`customTemplate`](#customTemplate) below.                               |
 | `namedExports`       | `true`                             | Enables named exports for compatible classnames.                             |
 | `dotenvOptions`      | `{}`                               | Provides options for [`dotenv`](https://github.com/motdotla/dotenv#options). |
-| `postCssOptions`     | `{}`                               | See [`postCssOptions`](#postCssOptions) below.                               |
+| `postcssOptions`     | `{}`                               | See [`postcssOptions`](#postcssOptions) below.                               |
 | `rendererOptions`    | `{}`                               | See [`rendererOptions`](#rendererOptions) below.                             |
 
 ```json
@@ -119,7 +119,7 @@ Please note that no options are required. However, depending on your configurati
           "customMatcher": "\\.m\\.css$",
           "customRenderer": "./myRenderer.js",
           "dotenvOptions": {},
-          "postCssOptions": {},
+          "postcssOptions": {},
           "rendererOptions": {}
         }
       }
@@ -192,7 +192,7 @@ The [internal `logger`](https://github.com/mrmckeb/typescript-plugin-css-modules
 
 The `classes` object represents all the classnames extracted from the CSS Module. They are available if you want to add a custom representation of the CSS classes.
 
-#### `postCssOptions`
+#### `postcssOptions`
 
 | Option           | Default value | Description                                                                                                               |
 | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------- |

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,14 +60,15 @@ function init({ typescript: ts }: { typescript: typeof tsModule }) {
     }
 
     // Add postCSS config if enabled.
-    const postCssOptions = options.postCssOptions || {};
+    const postcssOptions =
+      options.postcssOptions || options.postCssOptions || {};
 
     let userPlugins: AcceptedPlugin[] = [];
-    if (postCssOptions.useConfig) {
+    if (postcssOptions.useConfig) {
       const postcssConfig = getPostCssConfigPlugins(directory);
       userPlugins = [
         filter({
-          exclude: postCssOptions.excludePlugins,
+          exclude: postcssOptions.excludePlugins,
           silent: true,
         }),
         ...postcssConfig,

--- a/src/options.ts
+++ b/src/options.ts
@@ -8,7 +8,7 @@ import { Logger } from './helpers/logger';
 // NOTE: Stylus doesn't directly export RenderOptions.
 type StylusRenderOptions = Parameters<typeof stylus>[1];
 
-export interface PostCssOptions {
+export interface PostcssOptions {
   excludePlugins?: string[];
   useConfig?: boolean;
 }
@@ -26,7 +26,9 @@ export interface Options {
   customTemplate?: string;
   dotenvOptions?: DotenvConfigOptions;
   namedExports?: boolean;
-  postCssOptions?: PostCssOptions;
+  postcssOptions?: PostcssOptions;
+  /** @deprecated To align with other projects. */
+  postCssOptions?: PostcssOptions;
   rendererOptions?: RendererOptions;
 }
 


### PR DESCRIPTION
Based on feedback and research, we'll deprecate `postCss[...]` in favour of `postcss[...]`. See #127 for notes.

Both will be supported for the foreseeable future - this should be a soft deprecation only.

Closes #127.