### PR TITLE
feat: improves resolution of alias path imports

### DIFF
--- a/src/helpers/__tests__/__snapshots__/getDtsSnapshot.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/getDtsSnapshot.test.ts.snap
@@ -13,7 +13,9 @@ exports[`utils / cssSnapshots with baseUrl and paths in compilerOptions sass sho
 Object {
   "big-font": "tsconfig-paths-module__big-font---3FOK9",
   "class-with-mixin": "tsconfig-paths-module__class-with-mixin---Uo34z",
+  "main": "tsconfig-paths-module__main---2Ef_0",
   "public-module": "tsconfig-paths-module__public-module---2IHe1",
+  "text-bold": "tsconfig-paths-module__text-bold---h-81b",
 }
 `;
 

--- a/src/helpers/__tests__/external/package/_helpers.scss
+++ b/src/helpers/__tests__/external/package/_helpers.scss
@@ -1,0 +1,3 @@
+.text-bold {
+  font-weight: bold;
+}

--- a/src/helpers/__tests__/external/package/base.css
+++ b/src/helpers/__tests__/external/package/base.css
@@ -1,0 +1,3 @@
+.main {
+  margin: 0;
+}

--- a/src/helpers/__tests__/fixtures/tsconfig-paths.module.scss
+++ b/src/helpers/__tests__/fixtures/tsconfig-paths.module.scss
@@ -1,2 +1,4 @@
 @import '@scss/_external.module.scss';
 @import 'alias.scss';
+@import '@scss/helpers';
+@import '@scss/base';

--- a/src/helpers/getClasses.ts
+++ b/src/helpers/getClasses.ts
@@ -6,6 +6,7 @@ import stylus from 'stylus';
 import { CSSExports, extractICSS } from 'icss-utils';
 import tsModule from 'typescript/lib/tsserverlibrary';
 import { createMatchPath } from 'tsconfig-paths';
+import { fileExistsSync } from 'tsconfig-paths/lib/filesystem';
 import { sassTildeImporter } from '../importers/sassTildeImporter';
 import { Options, CustomRenderer } from '../options';
 import { Logger } from './logger';
@@ -78,7 +79,19 @@ export const getClasses = ({
         baseUrl && paths ? createMatchPath(path.resolve(baseUrl), paths) : null;
 
       const aliasImporter: sass.Importer = (url) => {
-        const newUrl = matchPath !== null ? matchPath(url) : undefined;
+        const newUrl =
+          matchPath !== null
+            ? matchPath(
+                url,
+                undefined,
+                (name) =>
+                  fileExistsSync(name) ||
+                  fileExistsSync(
+                    path.join(path.dirname(name), '_' + path.basename(name)),
+                  ),
+                ['.scss', '.sass', '.css'],
+              )
+            : undefined;
         return newUrl ? { file: newUrl } : null;
       };
 


### PR DESCRIPTION
Instead of specifying the full filename – which was what was being required, even though the alias paths were set:

```scss
@import 'alias/path/stylesheet.sass';
@import 'alias/path/_variables.scss';
@import 'alias/path/base.css';

// or

@use 'alias/path/stylesheet.sass';
@use 'alias/path/_variables.scss';
@use 'alias/path/base.css';
```

One can now specify just the part of the filename that really "matters" for Sass/SCSS:

```scss
@import 'alias/path/stylesheet';
@import 'alias/path/variables';
@import 'alias/path/base';

// or

@use 'alias/path/stylesheet';
@use 'alias/path/variables';
@use 'alias/path/base';
```