### PR TITLE
fix: pass through project root to Sass and Less

### DIFF
--- a/src/helpers/__tests__/getDtsSnapshot.test.ts
+++ b/src/helpers/__tests__/getDtsSnapshot.test.ts
@@ -237,6 +237,7 @@ describe('utils / cssSnapshots', () => {
       options,
       processor,
       compilerOptions,
+      directory: __dirname,
     });
 
     it('should return an object with classes, css, and a source map', () => {
@@ -275,6 +276,7 @@ describe('utils / cssSnapshots', () => {
       options,
       processor,
       compilerOptions,
+      directory: __dirname,
     });
 
     it('should return a dts file with only possibly undefined strings', () => {

--- a/src/helpers/__tests__/getDtsSnapshot.test.ts
+++ b/src/helpers/__tests__/getDtsSnapshot.test.ts
@@ -51,6 +51,7 @@ describe('utils / cssSnapshots', () => {
         options,
         processor,
         compilerOptions,
+        directory: __dirname,
       });
     });
 
@@ -113,6 +114,7 @@ describe('utils / cssSnapshots', () => {
         options,
         processor,
         compilerOptions,
+        directory: __dirname,
       });
 
       expect(cssExports.classes.test).toMatchSnapshot();
@@ -134,6 +136,7 @@ describe('utils / cssSnapshots', () => {
         options,
         processor,
         compilerOptions,
+        directory: __dirname,
       });
 
       expect(cssExports.classes).toMatchSnapshot();
@@ -159,6 +162,7 @@ describe('utils / cssSnapshots', () => {
         options,
         processor,
         compilerOptions,
+        directory: __dirname,
       });
 
       expect(cssExports.classes).toMatchSnapshot();
@@ -185,6 +189,7 @@ describe('utils / cssSnapshots', () => {
         options,
         processor,
         compilerOptions,
+        directory: __dirname,
       });
 
       expect(cssExports.classes).toMatchSnapshot();
@@ -210,6 +215,7 @@ describe('utils / cssSnapshots', () => {
         options,
         processor,
         compilerOptions,
+        directory: __dirname,
       });
 
       expect(cssExports.classes).toMatchSnapshot();

--- a/src/helpers/getCssExports.ts
+++ b/src/helpers/getCssExports.ts
@@ -42,6 +42,7 @@ export const getCssExports = ({
   options,
   processor,
   compilerOptions,
+  directory,
 }: {
   css: string;
   fileName: string;
@@ -49,6 +50,7 @@ export const getCssExports = ({
   options: Options;
   processor: Processor;
   compilerOptions: tsModule.CompilerOptions;
+  directory: string;
 }): CSSExportsWithSourceMap => {
   try {
     const fileType = getFileType(fileName);
@@ -73,6 +75,7 @@ export const getCssExports = ({
             {
               syncImport: true,
               filename: fileName,
+              paths: [directory],
               ...(rendererOptions.less ?? {}),
             } as Less.Options,
             (error?: Less.RenderError, output?: Less.RenderOutput) => {
@@ -91,7 +94,7 @@ export const getCssExports = ({
         case FileType.sass: {
           const filePath = getFilePath(fileName);
           const { loadPaths, ...sassOptions } = rendererOptions.sass ?? {};
-          const { baseUrl, paths } = compilerOptions;
+          const { baseUrl = directory, paths } = compilerOptions;
           const matchPath =
             baseUrl && paths
               ? createMatchPath(path.resolve(baseUrl), paths)

--- a/src/helpers/getDtsSnapshot.ts
+++ b/src/helpers/getDtsSnapshot.ts
@@ -13,6 +13,7 @@ export const getDtsSnapshot = (
   options: Options,
   logger: Logger,
   compilerOptions: tsModule.CompilerOptions,
+  directory: string
 ): tsModule.IScriptSnapshot => {
   const css = scriptSnapshot.getText(0, scriptSnapshot.getLength());
 
@@ -32,6 +33,7 @@ export const getDtsSnapshot = (
     options,
     processor,
     compilerOptions,
+    directory
   });
   const dts = createDtsExports({ cssExports, fileName, logger, options });
   return ts.ScriptSnapshot.fromString(dts);

--- a/src/helpers/getDtsSnapshot.ts
+++ b/src/helpers/getDtsSnapshot.ts
@@ -13,7 +13,7 @@ export const getDtsSnapshot = (
   options: Options,
   logger: Logger,
   compilerOptions: tsModule.CompilerOptions,
-  directory: string
+  directory: string,
 ): tsModule.IScriptSnapshot => {
   const css = scriptSnapshot.getText(0, scriptSnapshot.getLength());
 
@@ -33,7 +33,7 @@ export const getDtsSnapshot = (
     options,
     processor,
     compilerOptions,
-    directory
+    directory,
   });
   const dts = createDtsExports({ cssExports, fileName, logger, options });
   return ts.ScriptSnapshot.fromString(dts);

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ function init({ typescript: ts }: { typescript: typeof tsModule }) {
           options,
           logger,
           compilerOptions,
+          directory,
         );
       }
       const sourceFile = _createLanguageServiceSourceFile(
@@ -149,6 +150,7 @@ function init({ typescript: ts }: { typescript: typeof tsModule }) {
           options,
           logger,
           compilerOptions,
+          directory,
         );
       }
       sourceFile = _updateLanguageServiceSourceFile(


### PR DESCRIPTION
fixes an issue with `scss` and `less` files not respecting the project's root directory when importing other files by passing the ts root directory information to the renderer.

Should fix #146

* `less` fix is tested on my local machine.
* `scss` fix is untested. 
* This commit does not add any new test for this feature, but old tests are fixed