### PR TITLE
Fix docs: `jumpToDefinition` -> `goToDefinition`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,17 @@ const b = styles['my_other-class'];
 
 Please note that no options are required. However, depending on your configuration, you may need to customise these options.
 
-| Option               | Default value                      | Description                                                                                                |
-| -------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `classnameTransform` | `asIs`                             | See [`classnameTransform`](#classnameTransform) below.                                                     |
-| `customMatcher`      | `"\\.module\\.(c\|le\|sa\|sc)ss$"` | Changes the file extensions that this plugin processes.                                                    |
-| `customRenderer`     | `false`                            | See [`customRenderer`](#customRenderer) below.                                                             |
-| `customTemplate`     | `false`                            | See [`customTemplate`](#customTemplate) below.                                                             |
-| `jumpToDefinition`   | `false`                            | Enables jump to definition, with limited compatibility. See [`jumpToDefinition`](#jumpToDefinition) below. |
-| `namedExports`       | `true`                             | Enables named exports for compatible classnames.                                                           |
-| `dotenvOptions`      | `{}`                               | Provides options for [`dotenv`](https://github.com/motdotla/dotenv#options).                               |
-| `postcssOptions`     | `{}`                               | See [`postcssOptions`](#postcssOptions) below.                                                             |
-| `rendererOptions`    | `{}`                               | See [`rendererOptions`](#rendererOptions) below.                                                           |
+| Option               | Default value                      | Description                                                                                            |
+| -------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `classnameTransform` | `asIs`                             | See [`classnameTransform`](#classnameTransform) below.                                                 |
+| `customMatcher`      | `"\\.module\\.(c\|le\|sa\|sc)ss$"` | Changes the file extensions that this plugin processes.                                                |
+| `customRenderer`     | `false`                            | See [`customRenderer`](#customRenderer) below.                                                         |
+| `customTemplate`     | `false`                            | See [`customTemplate`](#customTemplate) below.                                                         |
+| `goToDefinition`     | `false`                            | Enables jump to definition, with limited compatibility. See [`goToDefinition`](#goToDefinition) below. |
+| `namedExports`       | `true`                             | Enables named exports for compatible classnames.                                                       |
+| `dotenvOptions`      | `{}`                               | Provides options for [`dotenv`](https://github.com/motdotla/dotenv#options).                           |
+| `postcssOptions`     | `{}`                               | See [`postcssOptions`](#postcssOptions) below.                                                         |
+| `rendererOptions`    | `{}`                               | See [`rendererOptions`](#rendererOptions) below.                                                       |
 
 ```json
 {
@@ -193,7 +193,7 @@ The [internal `logger`](https://github.com/mrmckeb/typescript-plugin-css-modules
 
 The `classes` object represents all the classnames extracted from the CSS Module. They are available if you want to add a custom representation of the CSS classes.
 
-#### `jumpToDefinition`
+#### `goToDefinition`
 
 This allows an editor like Visual Studio Code to jump to a classname's definition (file and line).
 

--- a/src/helpers/__tests__/__snapshots__/getDtsSnapshot.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/getDtsSnapshot.test.ts.snap
@@ -19,7 +19,7 @@ Object {
 
 exports[`utils / cssSnapshots with file 'empty.module.less' createExports should create an exports file 1`] = `
 "declare let classes: {
-
+  
 };
 export default classes;
 "
@@ -30,7 +30,7 @@ exports[`utils / cssSnapshots with file 'empty.module.less' getCssExports should
 exports[`utils / cssSnapshots with file 'empty.module.less' with a custom template should transform the generated dts 1`] = `
 "/* eslint-disable */
 declare let classes: {
-
+  
 };
 export default classes;
 
@@ -40,7 +40,7 @@ export type AllClassNames = '';"
 
 exports[`utils / cssSnapshots with file 'empty.module.sass' createExports should create an exports file 1`] = `
 "declare let classes: {
-
+  
 };
 export default classes;
 "
@@ -51,7 +51,7 @@ exports[`utils / cssSnapshots with file 'empty.module.sass' getCssExports should
 exports[`utils / cssSnapshots with file 'empty.module.sass' with a custom template should transform the generated dts 1`] = `
 "/* eslint-disable */
 declare let classes: {
-
+  
 };
 export default classes;
 
@@ -61,7 +61,7 @@ export type AllClassNames = '';"
 
 exports[`utils / cssSnapshots with file 'empty.module.scss' createExports should create an exports file 1`] = `
 "declare let classes: {
-
+  
 };
 export default classes;
 "
@@ -72,7 +72,7 @@ exports[`utils / cssSnapshots with file 'empty.module.scss' getCssExports should
 exports[`utils / cssSnapshots with file 'empty.module.scss' with a custom template should transform the generated dts 1`] = `
 "/* eslint-disable */
 declare let classes: {
-
+  
 };
 export default classes;
 
@@ -82,7 +82,7 @@ export type AllClassNames = '';"
 
 exports[`utils / cssSnapshots with file 'empty.module.styl' createExports should create an exports file 1`] = `
 "declare let classes: {
-
+  
 };
 export default classes;
 "
@@ -93,7 +93,7 @@ exports[`utils / cssSnapshots with file 'empty.module.styl' getCssExports should
 exports[`utils / cssSnapshots with file 'empty.module.styl' with a custom template should transform the generated dts 1`] = `
 "/* eslint-disable */
 declare let classes: {
-
+  
 };
 export default classes;
 
@@ -497,13 +497,18 @@ exports[`utils / cssSnapshots with file 'test.module.scss' createExports should 
   'section-8': string;
   'section-9': string;
   'class-with-mixin': string;
+  'App_logo': string;
+  'App-logo': string;
 };
 export default classes;
+export let App_logo: string;
 "
 `;
 
 exports[`utils / cssSnapshots with file 'test.module.scss' getCssExports should return an object matching expected CSS 1`] = `
 Object {
+  "App-logo": "test-module__App-logo---3S1C4",
+  "App_logo": "test-module__App_logo---1llXs",
   "child-class": "test-module__child-class---s-_Mc",
   "class-with-mixin": "test-module__class-with-mixin---1JqB_",
   "const": "test-module__const---28kKv",
@@ -550,11 +555,14 @@ declare let classes: {
   'section-8': string;
   'section-9': string;
   'class-with-mixin': string;
+  'App_logo': string;
+  'App-logo': string;
 };
 export default classes;
+export let App_logo: string;
 
 export const __cssModule: true;
-export type AllClassNames = 'local-class-inside-global' | 'local-class' | 'local-class-2' | 'local-class-inside-local' | 'reserved-words' | 'default' | 'const' | 'nested-class-parent' | 'child-class' | 'nested-class-parent--extended' | 'section-1' | 'section-2' | 'section-3' | 'section-4' | 'section-5' | 'section-6' | 'section-7' | 'section-8' | 'section-9' | 'class-with-mixin';"
+export type AllClassNames = 'local-class-inside-global' | 'local-class' | 'local-class-2' | 'local-class-inside-local' | 'reserved-words' | 'default' | 'const' | 'nested-class-parent' | 'child-class' | 'nested-class-parent--extended' | 'section-1' | 'section-2' | 'section-3' | 'section-4' | 'section-5' | 'section-6' | 'section-7' | 'section-8' | 'section-9' | 'class-with-mixin' | 'App_logo' | 'App-logo';"
 `;
 
 exports[`utils / cssSnapshots with file 'test.module.styl' createExports should create an exports file 1`] = `

--- a/src/helpers/__tests__/__snapshots__/getDtsSnapshot.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/getDtsSnapshot.test.ts.snap
@@ -707,6 +707,135 @@ export let appLogo: string;
 "
 `;
 
+exports[`utils / cssSnapshots with goToDefinition enabled should return an object with classes, css, and a source map 1`] = `
+Object {
+  "classes": Object {
+    "App-logo": "test-module__App-logo---3S1C4",
+    "App_logo": "test-module__App_logo---1llXs",
+    "child-class": "test-module__child-class---s-_Mc",
+    "class-with-mixin": "test-module__class-with-mixin---1JqB_",
+    "const": "test-module__const---28kKv",
+    "default": "test-module__default---8gLb1",
+    "local-class": "test-module__local-class---1Ju3l",
+    "local-class-2": "test-module__local-class-2---3aSgy",
+    "local-class-inside-global": "test-module__local-class-inside-global---IVh9J",
+    "local-class-inside-local": "test-module__local-class-inside-local---1LKIi",
+    "nested-class-parent": "test-module__nested-class-parent---2LnTV",
+    "nested-class-parent--extended": "test-module__nested-class-parent--extended---1j85b",
+    "reserved-words": "test-module__reserved-words---1mM1m",
+    "section-1": "test-module__section-1---11Ic3",
+    "section-2": "test-module__section-2---1Uiwc",
+    "section-3": "test-module__section-3---2eZeM",
+    "section-4": "test-module__section-4---3m8sf",
+    "section-5": "test-module__section-5---1MTwN",
+    "section-6": "test-module__section-6---szUAt",
+    "section-7": "test-module__section-7---2DOBJ",
+    "section-8": "test-module__section-8---3qav2",
+    "section-9": "test-module__section-9---2EMR_",
+  },
+  "css": ".global-class {
+  color: rebeccapurple;
+}
+
+.global-class-2 .test-module__local-class-inside-global---IVh9J {
+  color: rebeccapurple;
+}
+
+.test-module__local-class---1Ju3l {
+  color: rebeccapurple;
+}
+
+.test-module__local-class-2---3aSgy .test-module__local-class-inside-local---1LKIi {
+  color: rebeccapurple;
+}
+
+.test-module__reserved-words---1mM1m .test-module__default---8gLb1 {
+  color: rebeccapurple;
+}
+
+.test-module__reserved-words---1mM1m .test-module__const---28kKv {
+  color: rebeccapurple;
+}
+
+.test-module__nested-class-parent---2LnTV .test-module__child-class---s-_Mc {
+  color: rebeccapurple;
+}
+
+.test-module__nested-class-parent--extended---1j85b {
+  color: rebeccapurple;
+}
+
+.test-module__section-1---11Ic3 {
+  color: rebeccapurple;
+}
+
+.test-module__section-2---1Uiwc {
+  color: rebeccapurple;
+}
+
+.test-module__section-3---2eZeM {
+  color: rebeccapurple;
+}
+
+.test-module__section-4---3m8sf {
+  color: rebeccapurple;
+}
+
+.test-module__section-5---1MTwN {
+  color: rebeccapurple;
+}
+
+.test-module__section-6---szUAt {
+  color: rebeccapurple;
+}
+
+.test-module__section-7---2DOBJ {
+  color: rebeccapurple;
+}
+
+.test-module__section-8---3qav2 {
+  color: rebeccapurple;
+}
+
+.test-module__section-9---2EMR_ {
+  color: rebeccapurple;
+}
+
+.test-module__class-with-mixin---1JqB_ {
+  margin: 0;
+}
+
+.test-module__App_logo---1llXs {
+  height: 40vmin;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .test-module__App-logo---3S1C4 {
+    animation: my-animation infinite 20s linear;
+  }
+}
+
+/*
+.commented-parent-class {
+  .commented-child-class
+}
+*/
+/*# sourceMappingURL=src/helpers/__tests__/fixtures/test.module.scss.map */",
+  "sourceMap": Object {
+    "file": "src/helpers/__tests__/fixtures/test.module.scss",
+    "mappings": "AAAA;EACE,oBAAA;ACCF;;ADGE;EACE,oBAAA;ACAJ;;ADIA;EACE,oBAAA;ACDF;;ADKE;EACE,oBAAA;ACFJ;;ADOE;EACE,oBAAA;ACJJ;;ADME;EACE,oBAAA;ACJJ;;ADSE;EACE,oBAAA;ACNJ;;ADQE;EACE,oBAAA;ACNJ;;ADaE;EACE,oBAJI;ACNR;;ADSE;EACE,oBAJI;ACFR;;ADKE;EACE,oBAJI;ACER;;ADCE;EACE,oBAJI;ACMR;;ADHE;EACE,oBAJI;ACUR;;ADPE;EACE,oBAJI;ACcR;;ADXE;EACE,oBAJI;ACkBR;;ADfE;EACE,oBAJI;ACsBR;;ADnBE;EACE,oBAJI;AC0BR;;ADhBA;EE/CE,SFgDoB;ACmBtB;;ADhBA;EACE,cAAA;EACA,oBAAA;ACmBF;;ADhBA;EACE;IACE,2CAAA;ECmBF;AACF;;ADZA;;;;CAAA",
+    "names": Array [],
+    "sources": Array [
+      "file:///Users/oliverash/Development/typescript-plugin-css-modules/src/helpers/__tests__/fixtures/test.module.scss",
+      "src/helpers/__tests__/fixtures/test.module.scss",
+      "file:///Users/oliverash/Development/typescript-plugin-css-modules/src/helpers/__tests__/fixtures/_mixin.scss",
+    ],
+    "version": 3,
+  },
+}
+`;
+
 exports[`utils / cssSnapshots with includePaths in sass options should find external file from includePaths 1`] = `
 Object {
   "big-font": "include-path-module__big-font---Td7hY",

--- a/src/helpers/__tests__/getDtsSnapshot.test.ts
+++ b/src/helpers/__tests__/getDtsSnapshot.test.ts
@@ -231,7 +231,7 @@ describe('utils / cssSnapshots', () => {
       expect(cssExports).toMatchSnapshot();
     });
 
-    it.only('should return a line-accurate dts file', () => {
+    it('should return a line-accurate dts file', () => {
       const dts = createDtsExports({
         cssExports,
         fileName,


### PR DESCRIPTION
This looks like a mistake.

Also removes `.only`.