### PR TITLE
Fix use of non-init provided typescript lib, use consistent imports

### DIFF
--- a/src/helpers/__tests__/getDtsSnapshot.test.ts
+++ b/src/helpers/__tests__/getDtsSnapshot.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import postcssImportSync from 'postcss-import-sync2';
 import postcssPresetEnv from 'postcss-preset-env';
-import tsModule from 'typescript/lib/tsserverlibrary';
+import type tsModule from 'typescript/lib/tsserverlibrary';
 import { CSSExportsWithSourceMap, getCssExports } from '../getCssExports';
 import { createDtsExports } from '../createDtsExports';
 import { Logger } from '../logger';

--- a/src/helpers/getCssExports.ts
+++ b/src/helpers/getCssExports.ts
@@ -5,7 +5,7 @@ import sass from 'sass';
 import stylus from 'stylus';
 import { CSSExports, extractICSS } from 'icss-utils';
 import { RawSourceMap } from 'source-map-js';
-import tsModule from 'typescript/lib/tsserverlibrary';
+import type tsModule from 'typescript/lib/tsserverlibrary';
 import { createMatchPath } from 'tsconfig-paths';
 import { sassTildeImporter } from '../importers/sassTildeImporter';
 import { Options, CustomRenderer } from '../options';

--- a/src/helpers/getDtsSnapshot.ts
+++ b/src/helpers/getDtsSnapshot.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import tsModule from 'typescript/lib/tsserverlibrary';
+import type tsModule from 'typescript/lib/tsserverlibrary';
 import { Options } from '../options';
 import { getCssExports } from './getCssExports';
 import { createDtsExports } from './createDtsExports';

--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -1,11 +1,13 @@
-import { server } from 'typescript/lib/tsserverlibrary';
+import type tsModule from 'typescript/lib/tsserverlibrary';
 
 export interface Logger {
   log: (message: string) => void;
   error: (error: unknown) => void;
 }
 
-export const createLogger = (info: server.PluginCreateInfo): Logger => {
+export const createLogger = (
+  info: tsModule.server.PluginCreateInfo,
+): Logger => {
   const log = (message: string) => {
     info.project.projectService.logger.info(
       `[typescript-plugin-css-modules] ${message}`,

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,5 @@
 import { Options as SassOptions } from 'sass';
-import tsModule from 'typescript/lib/tsserverlibrary';
+import type tsModule from 'typescript/lib/tsserverlibrary';
 import { DotenvConfigOptions } from 'dotenv';
 import { CSSExports } from 'icss-utils';
 import stylus from 'stylus';


### PR DESCRIPTION
I mentioned this on https://github.com/mrmckeb/typescript-plugin-css-modules/pull/211#discussion_r1133048494, but, it was straightforward to send a PR for.

This PR:

- Makes imports consistent, named `tsModule` and `type` imported.
- Doesn't use any values from an imported typescript, as the one provided by `init` is the right one to be using.