### PR TITLE
fix: check if file exists before processing

### DIFF
--- a/src/helpers/getDtsSnapshot.ts
+++ b/src/helpers/getDtsSnapshot.ts
@@ -15,16 +15,21 @@ export const getDtsSnapshot = (
   compilerOptions: tsModule.CompilerOptions,
   directory: string,
 ): tsModule.IScriptSnapshot => {
-  const css = readFileSync(fileName, 'utf-8');
-  const cssExports = getCssExports({
-    css,
-    fileName,
-    logger,
-    options,
-    processor,
-    compilerOptions,
-    directory,
-  });
-  const dts = createDtsExports({ cssExports, fileName, logger, options });
-  return ts.ScriptSnapshot.fromString(dts);
+  try {
+    const css = readFileSync(fileName, 'utf-8');
+    const cssExports = getCssExports({
+      css,
+      fileName,
+      logger,
+      options,
+      processor,
+      compilerOptions,
+      directory,
+    });
+    const dts = createDtsExports({ cssExports, fileName, logger, options });
+    return ts.ScriptSnapshot.fromString(dts);
+  }
+  catch (e) {
+    logger.error(e);
+  }
 };

--- a/src/helpers/getDtsSnapshot.ts
+++ b/src/helpers/getDtsSnapshot.ts
@@ -15,21 +15,16 @@ export const getDtsSnapshot = (
   compilerOptions: tsModule.CompilerOptions,
   directory: string,
 ): tsModule.IScriptSnapshot => {
-  try {
-    const css = readFileSync(fileName, 'utf-8');
-    const cssExports = getCssExports({
-      css,
-      fileName,
-      logger,
-      options,
-      processor,
-      compilerOptions,
-      directory,
-    });
-    const dts = createDtsExports({ cssExports, fileName, logger, options });
-    return ts.ScriptSnapshot.fromString(dts);
-  }
-  catch (e) {
-    logger.error(e);
-  }
+  const css = readFileSync(fileName, 'utf-8');
+  const cssExports = getCssExports({
+    css,
+    fileName,
+    logger,
+    options,
+    processor,
+    compilerOptions,
+    directory,
+  });
+  const dts = createDtsExports({ cssExports, fileName, logger, options });
+  return ts.ScriptSnapshot.fromString(dts);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,8 @@ const init: tsModule.server.PluginModuleFactory = ({ typescript: ts }) => {
     };
 
     languageServiceHost.getScriptSnapshot = (fileName) => {
-      if (isCSS(fileName)) {
+      const fileExists = fs.existsSync(fileName);
+      if (fileExists && isCSS(fileName)) {
         return getDtsSnapshot(
           ts,
           processor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,8 +126,7 @@ const init: tsModule.server.PluginModuleFactory = ({ typescript: ts }) => {
     };
 
     languageServiceHost.getScriptSnapshot = (fileName) => {
-      const fileExists = fs.existsSync(fileName);
-      if (fileExists && isCSS(fileName)) {
+      if (isCSS(fileName) && fs.existsSync(fileName)) {
         return getDtsSnapshot(
           ts,
           processor,


### PR DESCRIPTION
This prevents the VSCode plugin from crashing when an imported css/scss/etc... file does not exist.

A more elegant solution would be to check if the file exists before the `readFileSync` call.

Will also fix: https://github.com/mrmckeb/typescript-plugin-css-modules/issues/216