### PR TITLE
add support for disabling the plugin via TS_PLUGIN_CSS_MODULES_DISALBED

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ If you're not using Visual Studio Code or are having trouble with the above meth
 
 You can include these logs with any issues you open for this project.
 
+### Disabling the plugin
+
+If your project uses the plugin but you are experiencing issues with it, you can disable it for yourself by defining the environment variable `TS_PLUGIN_CSS_MODULES_DISALBED`.
+
 ## About this project
 
 This project was inspired by a Create React App [issue](https://github.com/facebook/create-react-app/issues/5677)

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ const init: tsModule.server.PluginModuleFactory = ({ typescript: ts }) => {
   function create(
     info: tsModule.server.PluginCreateInfo,
   ): tsModule.LanguageService {
+    if (process.env.TS_PLUGIN_CSS_MODULES_DISALBED !== undefined) {
+      return info.languageService;
+    }
+
     const logger = createLogger(info);
     const directory = info.project.getCurrentDirectory();
     const compilerOptions = info.project.getCompilerOptions();


### PR DESCRIPTION

This follows a pattern I've seen in other plugins, like this from `typescript-eslint-language-service`:

https://github.com/Quramy/typescript-eslint-language-service/blob/da3c201c94dd3c3a6a10f83cbbd54fae9d3db9e1/src/plugin-module-factory.ts#L9

Reasoning:

When this plugin seems to be causing WebStorm some headaches (or certain versions of TS, etc) and I need to work on something else for a while, I find it tedious to comment it out from the `plugins` list of our `tsconfig`. The biggest headache there is that I often commit this commented-out code to my branches, only to have to revert it later when reviewing my PRs.

> I don't care too much about the methodology here re: env vars. Actually, starting my IDE with an env var is less than convenient, but it'll work. Other options could be checking for the existence of some file or what have you, but no matter what, it should be something either `gitignore`-able, or otherwise not a file in the repository.
