### PR TITLE
feat: Support for opt-in caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Please note that no options are required. However, depending on your configurati
 | `dotenvOptions`            | `{}`                                       | Provides options for [`dotenv`](https://github.com/motdotla/dotenv#options). Note that this plugin only accepts a `string` value for `path`. |
 | `postcssOptions`           | `{}`                                       | See [`postcssOptions`](#postcssOptions) below.                                                                                               |
 | `rendererOptions`          | `{}`                                       | See [`rendererOptions`](#rendererOptions) below.                                                                                             |
+| `caching`                  | `"never"`                                  | See [`caching`](#caching) below                                                                                                              |
 
 ```json
 {
@@ -239,6 +240,19 @@ This is experimental, and may not always work as expected. It currently supports
 | `stylus` | `{}`          | Set [renderer options for Stylus](https://stylus.bootcss.com/docs/js.html).          |
 
 > For convenience, `loadPaths` for Sass are extended, not replaced. The defaults are the path of the current file, and `'node_modules'`.
+
+#### `caching`
+
+Enables or disables caching.
+
+`"always"` will cache everything. This is overly agressive, and will cause stale types when CSS imported by CSS is modified.
+The cache key is the filename of the CSS file directly imported by TypeScript. Restarting the TypeScript server will clear the cache.
+
+`"never"` (default) regenerates types for every CSS file, every time any file is changed. This causes significant latency in editor
+operations (autocomplete, import suggestions, etc) in large projects, even when editing non-CSS files.
+
+Unfortunately, there's no balanced option or correct invalidation possible, due to typescript and the various CSS tools having
+different module loading systems.
 
 ### Visual Studio Code
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -35,7 +35,10 @@ export interface Options {
   /** @deprecated To align with naming in other projects. */
   postCssOptions?: PostcssOptions;
   rendererOptions?: RendererOptions;
+  caching?: CachingOptions;
 }
+
+export type CachingOptions = 'always' | 'never';
 
 export type ClassnameTransformOptions =
   | 'asIs'


### PR DESCRIPTION
This adds caching, which is off by default and enabled using `{caching: "always"}`. It works by mapping from snapshots provided by typescript to snapshots generated by the plugin using a WeakMap.

The `caching` option allows `"always" | "never"`. I chose to use a union instead of a bool to 1) later support for a third "only when safe" or "only when supported" option, and 2) to help indicate that it might be too aggressive since "always" sounds stronger than true.

Fixes #215

cc @jsliang 